### PR TITLE
feat: build and publish a linux appimage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build desktop installers
 
-# Produces the downloadable Mac (.dmg) and Windows (.exe) installers.
+# Produces the downloadable Mac (.dmg), Windows (.exe), and Linux (.AppImage)
+# installers.
 # Trigger by pushing a version tag (e.g. `git tag v0.1.0 && git push --tags`),
 # or run manually from the Actions tab. Artifacts are attached to a GitHub
 # Release so the README's download links resolve to real files.
@@ -24,6 +25,8 @@ jobs:
             script: dist:mac
           - os: windows-latest
             script: dist:win
+          - os: ubuntu-latest
+            script: dist:linux
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +99,7 @@ jobs:
           path: |
             release/*.dmg
             release/*.exe
+            release/*.AppImage
           if-no-files-found: warn
 
   release:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 | 🍎 **Mac** — Apple Silicon (M1 / M2 / M3 / M4 — most Macs since ~2020) | **[⬇ Download for Mac](https://github.com/Blueturboguy07/NitroAI/releases/latest/download/NitroAI-mac-arm64.dmg)** |
 | 🍎 **Mac** — older Intel models | **[⬇ Download for Intel Mac](https://github.com/Blueturboguy07/NitroAI/releases/latest/download/NitroAI-mac-x64.dmg)** |
 | 🪟 **Windows** — 10 or 11 | **[⬇ Download for Windows](https://github.com/Blueturboguy07/NitroAI/releases/latest/download/NitroAI-Setup-Windows.exe)** |
+| 🐧 **Linux** — 64-bit | **[⬇ Download for Linux](https://github.com/Blueturboguy07/NitroAI/releases/latest/download/NitroAI-Linux-x86_64.AppImage)** |
 
 *Not sure which Mac you have?* Click the Apple menu () at the top-left of your screen → **About This Mac**. If it says **Apple M1/M2/M3/M4**, use the Apple Silicon link; if it says **Intel**, use the Intel link.
 
@@ -18,6 +19,7 @@
 
 - **On Mac** — it just opens on a double-click, no warnings. ✅ (The app is signed and notarized by Apple.)
 - **On Windows** — you'll see a blue *"Windows protected your PC"* box the first time. That's normal for a brand-new app — click **More info → Run anyway** and it opens (and won't ask again). [Step-by-step below.](#first-time-opening-on-windows)
+- **On Linux** — a downloaded AppImage isn't executable yet. Either right-click it → **Properties** → tick **Allow executing file as program**, or run `chmod +x NitroAI-Linux-x86_64.AppImage` once. Then double-click it (or run `./NitroAI-Linux-x86_64.AppImage`). There's nothing to install.
 
 > **Just want to use NitroAI?** The links above are everything you need — enjoy. **Are you a developer?** Don't download the installer; [run it from source](#for-developers) instead so you have the code. You can also browse all versions on the [Releases page](https://github.com/Blueturboguy07/NitroAI/releases/latest).
 
@@ -29,7 +31,7 @@ NitroAI is an open-source, local-first study app. Point it at a document, a webs
 > **This is a starting point, not a finished product.** It's an open-source foundation meant to be forked, extended, and improved. It works and it's genuinely useful, but expect rough edges — treat it as a solid base to build on rather than a polished commercial app.
 
 > [!NOTE]
-> **Windows and macOS are both tested and working.** One Windows caveat: automatic setup of the local AI runtime (Ollama) isn't wired up there yet — on Windows, install [Ollama](https://ollama.com/download) once and NitroAI will use it, or just use a cloud key. (On macOS it's fully automatic.)
+> **Windows, macOS, and Linux are all tested and working.** One caveat on Windows and Linux: automatic setup of the local AI runtime (Ollama) isn't wired up there yet — install [Ollama](https://ollama.com/download) once (on Linux, your package manager has it) and NitroAI will find and use it, or just use a cloud key. (On macOS it's fully automatic.)
 
 ### First time opening on Windows
 
@@ -72,13 +74,14 @@ npm run app      # build, then launch the full desktop shell (Electron)
 Build installers locally:
 
 ```bash
-npm run dist:mac   # → release/NitroAI-<version>-<arch>.dmg
-npm run dist:win   # → release/NitroAI-Setup-<version>.exe
+npm run dist:mac    # → release/NitroAI-<version>-<arch>.dmg
+npm run dist:win    # → release/NitroAI-Setup-<version>.exe
+npm run dist:linux  # → release/NitroAI-Linux-x86_64.AppImage
 ```
 
 Or let CI do it: push a tag (`git tag v0.1.0 && git push --tags`) and the
-[release workflow](.github/workflows/release.yml) builds macOS + Windows
-installers and attaches them to a GitHub Release.
+[release workflow](.github/workflows/release.yml) builds macOS, Windows, and
+Linux installers and attaches them to a GitHub Release.
 
 Other scripts: `npm test` (Vitest), `npm run typecheck`.
 

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -69,5 +69,6 @@ module.exports = {
   linux: {
     target: ["AppImage"],
     category: "Education",
+    artifactName: "NitroAI-Linux-x86_64.${ext}",
   },
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",
+    "dist:linux": "npm run build && electron-builder --linux",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/server/ollama.mjs
+++ b/server/ollama.mjs
@@ -94,10 +94,16 @@ async function fetchArchive(onLog) {
      /usr/local/bin     Homebrew on Intel, and the symlink Ollama.app offers to
                         create on first launch
      Ollama.app/Contents/Resources/ollama  the official app's own CLI, which is
-                        there even when the user declined that symlink */
+                        there even when the user declined that symlink
+     /usr/bin/ollama    where every Linux distro package puts it (pacman, apt,
+                        dnf). A packaged AppImage started from a desktop
+                        launcher gets the session PATH, but that is not
+                        guaranteed — and without this entry a machine with
+                        Ollama plainly installed reports "not installed",
+                        because none of the paths above exist on Linux. */
 function knownInstallPaths() {
   if (process.platform === "win32") return [];
-  const found = ["/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"];
+  const found = ["/opt/homebrew/bin/ollama", "/usr/local/bin/ollama", "/usr/bin/ollama"];
   if (process.platform === "darwin") {
     for (const apps of ["/Applications", path.join(os.homedir(), "Applications")]) {
       found.push(path.join(apps, "Ollama.app", "Contents", "Resources", "ollama"));


### PR DESCRIPTION
## What

Makes NitroAI installable on Linux. Five files, no refactors.

- `package.json` — add a `dist:linux` script alongside `dist:mac` / `dist:win`.
- `electron-builder.cjs` — give the existing `linux` block a stable `artifactName` (`NitroAI-Linux-x86_64.AppImage`) so the README can link to it the way the mac/win entries do.
- `.github/workflows/release.yml` — add an `ubuntu-latest` row to the build matrix and `release/*.AppImage` to the artifact upload. The macOS signing step is already gated on `runner.os == 'macOS'`, and the release job globs `artifacts/**/*`, so neither needed changing.
- `server/ollama.mjs` — add `/usr/bin/ollama` to `knownInstallPaths()`.
- `README.md` — Linux download row, the `chmod +x` note, and the platform caveat updated.

## Why

The `linux: { target: ["AppImage"] }` block already existed in `electron-builder.cjs`, but nothing ever built it — the release matrix covered macOS and Windows only, so no artifact was produced and there was no download link.

The Ollama change is a real bug, not tidying. `findBinary()` tries `which ollama` first, then falls back to `knownInstallPaths()`. On Linux that fallback list is empty in practice: `/opt/homebrew/bin` and `/usr/local/bin` don't exist on a normal distro install. So whenever the PATH lookup fails — which is exactly the packaged-app scenario the existing comment describes for launchd on macOS — a machine with Ollama installed from its distro package reports `installed: false`, and `provision()` fails with "Automatic Ollama setup isn't available on this platform yet."

Verified on this machine with PATH stripped:

```
before: null            -> status() reports installed:false
after:  /usr/bin/ollama -> installed:true
```

## Testing

Built and run on Arch Linux x86_64 (Hyprland/Wayland, Electron via XWayland).

- `npm test` — 109 passed; `npm run typecheck` clean.
- `npm run dist:linux` produces `release/NitroAI-Linux-x86_64.AppImage` (169 MB); it launches and renders.
- yt-dlp path exercised end to end — `ytdlpAsset()` correctly picks the plain `yt-dlp` Linux asset, downloads it, and extracted captions from a test video in ~6s.
- Local engine verified against a distro-packaged Ollama (`pacman -S ollama`, systemd unit): `/api/local/status` returns `{"installed":true,"serving":true,"hasChatModel":true,"hasEmbedModel":true}`, and the `/api/local/setup` flow pulled `qwen2.5:3b` successfully.

## Deliberately not included

Automatic Ollama **download** on Linux. The asset is `ollama-linux-amd64.tar.zst` — zstd rather than gzip, and it unpacks to `bin/ollama` + `lib/ollama/` rather than a flat binary, so it needs both a new decompress step and a second layout branch in `findBinary()`. `downloadBinary()` stays macOS-only and Linux gets the same "install it once" guidance Windows already has, which is a reasonable fit given every Linux distro ships an Ollama package. Happy to follow up separately if you'd rather have it.

## Note

The README's Linux download link 404s until the next tagged release, since the workflow only publishes on `v*` tags — same as any new artifact name.
